### PR TITLE
feat: strict send WC matching, log unmatched to agent_errors

### DIFF
--- a/src/rpingmesh/internal/agent/agent.go
+++ b/src/rpingmesh/internal/agent/agent.go
@@ -177,6 +177,21 @@ func (a *Agent) Start() error {
 	}
 	log.Debug().Msg("Agent UD queues initialized with ACK handler")
 
+	// Register unmatched send WC reporter to log to agent_errors (strict matching, no fallback to sendCompChan)
+	if a.errorLogger != nil {
+		reporter := func(deviceName, gid, ipAddr string, qpn uint32, wrID uint64) {
+			a.errorLogger.WriteUnmatchedSendWC(&errorlog.UnmatchedSendWCEntry{
+				Dev:  deviceName,
+				GID:  gid,
+				IP:   ipAddr,
+				QPN:  qpn,
+				WRID: wrID,
+				Host: a.agentState.GetHostName(),
+			})
+		}
+		a.agentState.SetUnmatchedWCReporter(reporter)
+	}
+
 	// Now that UD queues are ready (including those for the prober), start the prober's internal loops.
 	if err := a.prober.Start(); err != nil {
 		return fmt.Errorf("failed to start prober: %w", err)

--- a/src/rpingmesh/internal/agent/errorlog/errorlog.go
+++ b/src/rpingmesh/internal/agent/errorlog/errorlog.go
@@ -30,6 +30,18 @@ type TimeoutEntry struct {
 	AckTotal    int     `json:"ack_total"`    // always 2
 }
 
+// UnmatchedSendWCEntry represents a send completion whose WR-ID was not found in pendingSendChans.
+type UnmatchedSendWCEntry struct {
+	Type      string `json:"type"`  // "unmatched_send_wc"
+	Timestamp string `json:"ts"`    // ISO8601
+	Dev       string `json:"dev"`   // device name
+	GID       string `json:"gid"`
+	IP        string `json:"ip"`
+	QPN       uint32 `json:"qpn"`
+	WRID      uint64 `json:"wr_id"`
+	Host      string `json:"host"`
+}
+
 // AckSendTimeoutEntry represents an ACK send timeout (Responder failing to send ACK).
 type AckSendTimeoutEntry struct {
 	Type      string `json:"type"`       // "ack_send_timeout"
@@ -131,6 +143,32 @@ func (l *Logger) WriteAckSendTimeout(e *AckSendTimeoutEntry) {
 	data, err := json.Marshal(e)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to marshal ack_send_timeout entry")
+		return
+	}
+	line := append(data, '\n')
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n, err := l.file.Write(line)
+	if err != nil {
+		log.Warn().Err(err).Str("path", l.path).Msg("Failed to write error log")
+		return
+	}
+	l.size += int64(n)
+	if l.maxSizeMB > 0 && l.size >= int64(l.maxSizeMB)*1024*1024 {
+		l.rotate()
+	}
+}
+
+// WriteUnmatchedSendWC writes an unmatched send WC entry (agent_errors).
+func (l *Logger) WriteUnmatchedSendWC(e *UnmatchedSendWCEntry) {
+	if l == nil || !l.enabled {
+		return
+	}
+	e.Type = "unmatched_send_wc"
+	e.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	data, err := json.Marshal(e)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to marshal unmatched_send_wc entry")
 		return
 	}
 	line := append(data, '\n')

--- a/src/rpingmesh/internal/agent/errorlog/errorlog_test.go
+++ b/src/rpingmesh/internal/agent/errorlog/errorlog_test.go
@@ -187,3 +187,56 @@ func TestMixedTypesInSameLog(t *testing.T) {
 		t.Errorf("line1: expected type=ack_send_timeout, got %s", lines[1])
 	}
 }
+
+func TestUnmatchedSendWCEntryJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent_errors.log")
+	l, err := New(path, true, 20, 3)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer l.Close()
+
+	e := &UnmatchedSendWCEntry{
+		Dev:  "mlx5_0",
+		GID:  "::ffff:10.106.1.1",
+		IP:   "10.106.1.1",
+		QPN:  0x1234,
+		WRID: 987654321,
+		Host: "node001",
+	}
+	l.WriteUnmatchedSendWC(e)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	if !sc.Scan() {
+		t.Fatal("Expected one line")
+	}
+	line := sc.Text()
+	if !strings.Contains(line, `"type":"unmatched_send_wc"`) {
+		t.Errorf("Expected type=unmatched_send_wc, got %s", line)
+	}
+	if !strings.Contains(line, `"dev":"mlx5_0"`) {
+		t.Errorf("Expected dev=mlx5_0, got %s", line)
+	}
+	if !strings.Contains(line, `"gid":"::ffff:10.106.1.1"`) {
+		t.Errorf("Expected gid, got %s", line)
+	}
+	if !strings.Contains(line, `"ip":"10.106.1.1"`) {
+		t.Errorf("Expected ip, got %s", line)
+	}
+	if !strings.Contains(line, `"qpn":4660`) {
+		t.Errorf("Expected qpn=4660 (0x1234), got %s", line)
+	}
+	if !strings.Contains(line, `"wr_id":987654321`) {
+		t.Errorf("Expected wr_id=987654321, got %s", line)
+	}
+	if !strings.Contains(line, `"host":"node001"`) {
+		t.Errorf("Expected host=node001, got %s", line)
+	}
+}

--- a/src/rpingmesh/internal/rdma/cq.go
+++ b/src/rpingmesh/internal/rdma/cq.go
@@ -491,20 +491,19 @@ func (u *UDQueue) handleSendCompletion(gwc *GoWorkCompletion) {
 		return
 	}
 
-	// Fallback to shared sendCompChan if WR-ID not in pendingSendChans
-	log.Debug().
-		Str("qpn", fmt.Sprintf("0x%x", u.QPN)).
+	// Strict matching: WR-ID not found, log and report (no fallback to sendCompChan)
+	log.Warn().
+		Str("device", u.RNIC.DeviceName).
+		Str("gid", u.RNIC.GID).
+		Uint32("qpn", u.QPN).
 		Str("type", getQueueTypeString(u.QueueType)).
 		Uint64("wr_id", gwc.WRID).
-		Msg("[cq_poller] send completion falling back to shared sendCompChan (WR-ID not in pendingSendChans)")
-	select {
-	case u.sendCompChan <- gwc:
-	default:
-		log.Warn().
-			Str("qpn", fmt.Sprintf("0x%x", u.QPN)).
-			Str("type", getQueueTypeString(u.QueueType)).
-			Uint64("wr_id", gwc.WRID).
-			Msg("Send completion channel full, dropping WC_SEND event. gwc will be freed.")
+		Msg("[cq_poller] send completion WR-ID not in pendingSendChans, discarding (strict matching)")
+	u.unmatchedSendWCReporterMu.RLock()
+	reporter := u.unmatchedSendWCReporter
+	u.unmatchedSendWCReporterMu.RUnlock()
+	if reporter != nil {
+		reporter(u.RNIC.DeviceName, u.RNIC.GID, u.RNIC.IPAddr, u.QPN, gwc.WRID)
 	}
 }
 

--- a/src/rpingmesh/internal/rdma/queue.go
+++ b/src/rpingmesh/internal/rdma/queue.go
@@ -20,6 +20,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// UnmatchedSendWCReporter is called when a send completion's WR-ID is not found in pendingSendChans.
+type UnmatchedSendWCReporter func(deviceName, gid, ipAddr string, qpn uint32, wrID uint64)
+
 // UDQueueType defines the role of the UDQueue
 type UDQueueType int
 
@@ -76,6 +79,10 @@ type UDQueue struct {
 
 	// Per-WR-ID send completion channels for exact matching
 	pendingSendChans sync.Map // map[uint64]chan *GoWorkCompletion, key is sendWRID
+
+	// Optional reporter for unmatched send completions (WR-ID not in pendingSendChans)
+	unmatchedSendWCReporter   UnmatchedSendWCReporter
+	unmatchedSendWCReporterMu sync.RWMutex
 
 	// CQ polling goroutine control
 	cqPollerRunning bool
@@ -544,6 +551,13 @@ func (u *UDQueue) CreateAddressHandle(targetGID string, flowLabel uint32) (*C.st
 	}
 
 	return ah, nil
+}
+
+// SetUnmatchedWCReporter sets the optional reporter for unmatched send completions.
+func (u *UDQueue) SetUnmatchedWCReporter(reporter UnmatchedSendWCReporter) {
+	u.unmatchedSendWCReporterMu.Lock()
+	defer u.unmatchedSendWCReporterMu.Unlock()
+	u.unmatchedSendWCReporter = reporter
 }
 
 // Destroy releases all resources associated with the UD queue

--- a/src/rpingmesh/internal/state/state.go
+++ b/src/rpingmesh/internal/state/state.go
@@ -227,6 +227,18 @@ func (a *AgentState) GetResponderUDQueue(gid string) *rdma.UDQueue {
 	return a.responderQueues[gid]
 }
 
+// SetUnmatchedWCReporter sets the reporter for unmatched send completions on all UD queues.
+func (a *AgentState) SetUnmatchedWCReporter(reporter rdma.UnmatchedSendWCReporter) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	for _, q := range a.senderQueues {
+		q.SetUnmatchedWCReporter(reporter)
+	}
+	for _, q := range a.responderQueues {
+		q.SetUnmatchedWCReporter(reporter)
+	}
+}
+
 // GetRDMAManager returns the RDMA manager
 func (a *AgentState) GetRDMAManager() *rdma.RDMAManager {
 	a.mutex.RLock()


### PR DESCRIPTION
- Remove sendCompChan fallback for send completions without pre-WR-ID
- Add UnmatchedSendWCEntry and WriteUnmatchedSendWC to errorlog
- Add UnmatchedSendWCReporter callback on UDQueue
- Wire reporter in AgentState and agent.go when error log enabled
- Log unmatched send WCs to agent_errors for observability
- Add TestUnmatchedSendWCEntryJSON unit test

Made-with: Cursor